### PR TITLE
SFSafariViewController Reader Mode Support

### DIFF
--- a/Sources/RichText/RichTextEnums.swift
+++ b/Sources/RichText/RichTextEnums.swift
@@ -24,6 +24,7 @@ public enum fontType : String {
 
 public enum linkOpenType: String {
     case SFSafariView = "SFSafariView"
+    case SFSafariViewWithReader = "SFSafariViewWithReader"
     case Safari = "Safari"
     case none = "none"
 }

--- a/Sources/RichText/Webview.swift
+++ b/Sources/RichText/Webview.swift
@@ -63,7 +63,10 @@ struct Webview : UIViewRepresentable {
                     switch self.parent.linkOpenType {
                     case .SFSafariView:
                         root?.present(SFSafariViewController(url: url), animated: true, completion: nil)
-                        
+                    case .SFSafariViewWithReader:
+                        let configuration = SFSafariViewController.Configuration()
+                        configuration.entersReaderIfAvailable = true
+                        root?.present(SFSafariViewController(url: url, configuration: configuration), animated: true, completion: nil)
                     case .Safari :
                         UIApplication.shared.open(url)
                     case .none :


### PR DESCRIPTION
I added a new case to linkOpenType. When SFSafariViewWithReader case selected, RichText opens links with SFSafariViewController, on Reader mode if available.