### PR TITLE
[Fix] Always call decisionHandler on webview navigationAction

### DIFF
--- a/Sources/RichText/Views/Webview.swift
+++ b/Sources/RichText/Views/Webview.swift
@@ -121,7 +121,10 @@ extension WebView {
             }
             
             if url.scheme == nil {
-                guard let httpsURL = URL(string: "https://\(url.absoluteString)") else { return }
+                guard let httpsURL = URL(string: "https://\(url.absoluteString)") else {
+                    decisionHandler(WKNavigationActionPolicy.cancel)
+                    return
+                }
                 url = httpsURL
             }
             


### PR DESCRIPTION
This PR makes sure that `decissionHandler` is always called on a webview `navigationAction`.

Previously, it was possible that when URL scheme is nil and creating "https" URL failed, then `decissionHandler` would not be called. Not calling `decissionHandler` would cause app to crash.