### PR TITLE
#46 LinkOpenType Custom Handling for All URL Schemes

### DIFF
--- a/Sources/RichText/Views/Webview.swift
+++ b/Sources/RichText/Views/Webview.swift
@@ -120,52 +120,54 @@ extension WebView {
                 return
             }
             
-            if url.scheme == nil {
-                guard let httpsURL = URL(string: "https://\(url.absoluteString)") else {
-                    decisionHandler(WKNavigationActionPolicy.cancel)
-                    return
-                }
-                url = httpsURL
-            }
-            
-            switch url.scheme {
-            case "mailto", "tel":
-                #if canImport(UIKit)
-                UIApplication.shared.open(url, options: [:], completionHandler: nil)
-                #else
-                NSWorkspace.shared.open(url)
-                #endif
-            case "http", "https":
-                switch parent.conf.linkOpenType {
-                #if canImport(UIKit)
-                case let .SFSafariView(conf, isReaderActivated, isAnimated):
-                    if let reader = isReaderActivated {
-                        conf.entersReaderIfAvailable = reader
+            if case let .custom(action) = parent.conf.linkOpenType {
+                action(url)
+            } else {
+                if url.scheme == nil {
+                    guard let httpsURL = URL(string: "https://\(url.absoluteString)") else {
+                        decisionHandler(WKNavigationActionPolicy.cancel)
+                        return
                     }
-                    let root = UIApplication.shared.windows.first?.rootViewController
-                    root?.present(SFSafariViewController(url: url, configuration: conf), animated: isAnimated, completion: nil) #else
-                #endif
-                case .Safari:
+                    url = httpsURL
+                }
+                
+                switch url.scheme {
+                case "mailto", "tel":
                     #if canImport(UIKit)
                     UIApplication.shared.open(url, options: [:], completionHandler: nil)
                     #else
                     NSWorkspace.shared.open(url)
                     #endif
-                case let .custom(action):
-                    action(url)
-                case .none:
-                    break
+                case "http", "https":
+                    switch parent.conf.linkOpenType {
+                        #if canImport(UIKit)
+                    case let .SFSafariView(conf, isReaderActivated, isAnimated):
+                        if let reader = isReaderActivated {
+                            conf.entersReaderIfAvailable = reader
+                        }
+                        let root = UIApplication.shared.windows.first?.rootViewController
+                        root?.present(SFSafariViewController(url: url, configuration: conf), animated: isAnimated, completion: nil)
+                        #endif
+                    case .Safari:
+                        #if canImport(UIKit)
+                        UIApplication.shared.open(url, options: [:], completionHandler: nil)
+                        #else
+                        NSWorkspace.shared.open(url)
+                        #endif
+                    case .none, .custom:
+                        break
+                    }
+                default:
+                    #if canImport(UIKit)
+                    if UIApplication.shared.canOpenURL(url) {
+                        UIApplication.shared.open(url, options: [:], completionHandler: nil)
+                    }
+                    #else
+                    NSWorkspace.shared.open(url)
+                    #endif
                 }
-            default:
-                #if canImport(UIKit)
-                if UIApplication.shared.canOpenURL(url) {
-                    UIApplication.shared.open(url, options: [:], completionHandler: nil)
-                }
-                #else
-                NSWorkspace.shared.open(url)
-                #endif
             }
-
+            
             decisionHandler(WKNavigationActionPolicy.cancel)
         }
     }


### PR DESCRIPTION
## #46 LinkOpenType - custom type
Previously, the custom type's activation was restricted to URLs with 'http' and 'https' schemes.
This limitation has now been lifted, allowing the custom type to be universally applicable to all URL schemes.


```swift
if case let .custom(action) = parent.conf.linkOpenType {
    action(url)
} else { ... }
```