### PR TITLE
Allow setting the WebKit baseURL for requests to something other than the Bundle

### DIFF
--- a/Sources/RichText/Extensions/RichText+Extension.swift
+++ b/Sources/RichText/Extensions/RichText+Extension.swift
@@ -85,7 +85,13 @@ extension RichText {
         result.configuration.linkOpenType = linkOpenType
         return result
     }
-    
+
+    public func baseURL(_ baseURL: URL) -> RichText {
+        var result = self
+        result.configuration.baseURL = baseURL
+        return result
+    }
+
     public func colorPreference(forceColor: ColorPreference) -> RichText {
         var result = self
         result.configuration.isColorsImportant = forceColor

--- a/Sources/RichText/Models/Configuration.swift
+++ b/Sources/RichText/Models/Configuration.swift
@@ -21,6 +21,7 @@ public struct Configuration {
     
     public var linkOpenType: LinkOpenType
     public var linkColor: ColorSet
+    public var baseURL: URL?
     
     public var isColorsImportant: ColorPreference
     
@@ -35,6 +36,7 @@ public struct Configuration {
         imageRadius: CGFloat = 0,
         linkOpenType: LinkOpenType = .Safari,
         linkColor: ColorSet = .init(light: "007AFF", dark: "0A84FF", isImportant: true),
+        baseURL: URL? = Bundle.main.bundleURL,
         isColorsImportant: ColorPreference = .onlyLinks,
         transition: Animation? = .none
     ) {
@@ -46,6 +48,7 @@ public struct Configuration {
         self.imageRadius = imageRadius
         self.linkOpenType = linkOpenType
         self.linkColor = linkColor
+        self.baseURL = baseURL
         self.isColorsImportant = isColorsImportant
         self.transition = transition
     }

--- a/Sources/RichText/Views/Webview.swift
+++ b/Sources/RichText/Views/Webview.swift
@@ -35,8 +35,7 @@ extension WebView: UIViewRepresentable {
         webview.scrollView.isScrollEnabled = false
         
         DispatchQueue.main.async {
-            let bundleURL = Bundle.main.bundleURL
-            webview.loadHTMLString(generateHTML(), baseURL: bundleURL)
+            webview.loadHTMLString(generateHTML(), baseURL: conf.baseURL)
         }
         
         webview.isOpaque = false
@@ -48,8 +47,7 @@ extension WebView: UIViewRepresentable {
 
     func updateUIView(_ uiView: WKWebView, context: Context) {
         DispatchQueue.main.async {
-            let bundleURL = Bundle.main.bundleURL
-            uiView.loadHTMLString(generateHTML(), baseURL: bundleURL)
+            uiView.loadHTMLString(generateHTML(), baseURL: conf.baseURL)
         }
     }
 
@@ -70,8 +68,7 @@ extension WebView: NSViewRepresentable {
         let webview = ScrollAdjustedWKWebView()
         webview.navigationDelegate = context.coordinator
         DispatchQueue.main.async {
-            let bundleURL = Bundle.main.bundleURL
-            webview.loadHTMLString(generateHTML(), baseURL: bundleURL)
+            webview.loadHTMLString(generateHTML(), baseURL: conf.baseURL)
         }
         webview.setValue(false, forKey: "drawsBackground")
 
@@ -80,8 +77,7 @@ extension WebView: NSViewRepresentable {
 
     func updateNSView(_ nsView: WKWebView, context _: Context) {
         DispatchQueue.main.async {
-            let bundleURL = Bundle.main.bundleURL
-            nsView.loadHTMLString(generateHTML(), baseURL: bundleURL)
+            nsView.loadHTMLString(generateHTML(), baseURL: conf.baseURL)
         }
     }
 


### PR DESCRIPTION
Pretty simple change to support setting the baseURL. Still defaults to the Bundle, so it should have be no change to existing users.