### PR TITLE
feat: Add PrivacyInfo.xcprivacy file for issue #50

### DIFF
--- a/Sources/RichText/PrivacyInfo.xcprivacy
+++ b/Sources/RichText/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
This pull request adds a privacy manifest in compliance with the App Store guidelines effective from May 2024.

## Changes
- Added `PrivacyInfo.xcprivacy` file to detail the app's data use, adhering to the new policy requirements.

## Issue
Resolves #50