### PR TITLE
Add option to force color scheme background

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ Modifier | Default
 `.customCSS(_ customCSS: String)` | `""`
 `.lineHeight(_ lineHeight: CGFloat)` | `170`
 `.colorScheme(_ colorScheme: ColorScheme)` | `.auto`
+`.forceColorSchemeBackground(_ forceColorSchemeBackground: Bool)` | `false`
 `.fontType(_ fontType: FontType)` | `.system`
 `.linkColor(_ linkColor: ColorSet)` | `ColorSet(light: "#007AFF", dark: "#0A84FF", isImportant: true)`
 `.linkOpenType(_ linkOpenType: LinkOpenType)` | `.Safari`
@@ -258,6 +259,7 @@ Modifier | Default
  - customCSS(default: ""): You can add CSS if you want
  - lineHeight (default: 170)  : Height of each line
  - colorScheme(default: .auto) : light or dark mode (it changes text color)
+ - forceColorSchemeBackground (default: false) : force `colorScheme` background color to override inline css to ensure complete light/dark mode
  - fontType(default: .system): Font type in RichText view
  - linkColor (default: ColorSet(light: "#007AFF", dark: "#0A84FF")) : linkColor (Color or UIColor)
  - linkOpenType (default: .Safari) : When the user clicks the link contained in html, Way to take action

--- a/Sources/RichText/Extensions/RichText+Extension.swift
+++ b/Sources/RichText/Extensions/RichText+Extension.swift
@@ -25,6 +25,12 @@ extension RichText {
         result.configuration.colorScheme = colorScheme
         return result
     }
+    
+    public func forceColorSchemeBackground(_ forceColorSchemeBackground: Bool) -> RichText {
+        var result = self
+        result.configuration.forceColorSchemeBackground = forceColorSchemeBackground
+        return result
+    }
 
     public func imageRadius(_ imageRadius: CGFloat) -> RichText {
         var result = self

--- a/Sources/RichText/Models/Configuration.swift
+++ b/Sources/RichText/Models/Configuration.swift
@@ -18,6 +18,7 @@ public struct Configuration {
     public var lineHeight: CGFloat
     
     public var colorScheme: ColorScheme
+    public var forceColorSchemeBackground: Bool
     
     public var imageRadius: CGFloat
     
@@ -36,6 +37,7 @@ public struct Configuration {
         fontColor: ColorSet = .init(light: "000000", dark: "F2F2F2"),
         lineHeight: CGFloat = 170,
         colorScheme: ColorScheme = .auto,
+        forceColorSchemeBackground: Bool = false,
         imageRadius: CGFloat = 0,
         linkOpenType: LinkOpenType = .Safari,
         linkColor: ColorSet = .init(light: "007AFF", dark: "0A84FF", isImportant: true),
@@ -49,6 +51,7 @@ public struct Configuration {
         self.fontColor = fontColor
         self.lineHeight = lineHeight
         self.colorScheme = colorScheme
+        self.forceColorSchemeBackground = forceColorSchemeBackground
         self.imageRadius = imageRadius
         self.linkOpenType = linkOpenType
         self.linkColor = linkColor
@@ -78,10 +81,18 @@ public struct Configuration {
         }
     }
     
+    private func backgroundColor(_ isLight: Bool) -> String {
+        if isLight {
+            return "white \(forceColorSchemeBackground ? "!important": "")"
+        } else {
+            return "black \(forceColorSchemeBackground ? "!important": "")"
+        }
+    }
+    
     func css(isLight: Bool, alignment: TextAlignment) -> String {
         """
         img{max-height: 100%; min-height: 100%; height:auto; max-width: 100%; width:auto;margin-bottom:5px; border-radius: \(imageRadius)px;}
-        h1, h2, h3, h4, h5, h6, p, div, dl, ol, ul, pre, blockquote {text-align:\(alignment.htmlDescription); line-height: \(lineHeight)%; font-family: '\(fontType.name)' !important; color: \(fontColor.value(isLight)); }
+        h1, h2, h3, h4, h5, h6, p, div, dl, ol, ul, pre, blockquote {text-align:\(alignment.htmlDescription); line-height: \(lineHeight)%; font-family: '\(fontType.name)' !important; color: \(fontColor.value(isLight)); background-color: \(backgroundColor(isLight)); }
         iframe{width:100%; height:250px;}
         a:link {color: \(linkColor.value(isLight));}
         A {text-decoration: none;}

--- a/Sources/RichText/Views/RichText.swift
+++ b/Sources/RichText/Views/RichText.swift
@@ -36,6 +36,44 @@ public struct RichText: View {
 
 struct RichText_Previews: PreviewProvider {
     static var previews: some View {
-        RichText(html: "")
+        ScrollView {
+            RichText(
+                html: """
+            <h1 style="background-color: white;">Lorem Ipsum Test</h1>
+            <img 
+                src="https://miro.medium.com/v2/resize:fit:1400/1*JLYlSLSK8-AZo8gt9UdYqA.jpeg" 
+                alt="Denali mountain landscape" 
+              />
+            <p style="background-color: white;">
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed vitae suscipit neque. Nullam
+              imperdiet justo at felis dictum, nec laoreet risus fermentum. Mauris suscipit libero vel
+              erat porttitor, ac porttitor nisi pulvinar.
+            </p>
+            <p style="background-color: white;">
+              Donec in mi vel sem pharetra pulvinar. Aliquam erat volutpat. Morbi posuere justo at
+              efficitur pharetra. Aenean nec blandit nibh. Proin vel urna eget odio posuere blandit.
+            </p>
+            <h2 style="background-color: white;">Subheading</h2>
+            <p style="background-color: white;">
+              Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae;
+              Cras malesuada velit sit amet metus dapibus, at tristique est porttitor. Nunc lacinia
+              lectus sed quam lacinia, vel porta nulla fermentum. Curabitur at urna non nisl
+              scelerisque consequat.
+            </p>
+            <p style="background-color: white;">
+              Sed vitae turpis vitae purus accumsan faucibus. Suspendisse vel nibh tellus. Etiam et
+              tempor ante. Suspendisse sit amet orci id nisi euismod blandit. In hac habitasse platea
+              dictumst.
+            </p>
+            <p style="background-color: white;">
+              Pellentesque dignissim lacinia nisl at pretium. Etiam a rutrum nisi. Integer tincidunt
+              ipsum ut sapien gravida, a bibendum massa fermentum. Vivamus lacinia libero in nunc
+              eleifend suscipit. Maecenas ut tristique magna.
+            </p>
+            """
+            )
+            .forceColorSchemeBackground(true)
+            .padding()
+        }
     }
 }


### PR DESCRIPTION
This PR fixes #53.

In the case that a user's HTML includes inline CSS that is overriding the background color set by the `colorScheme` modifier, users can use the new `forceColorSchemeBackground` option. This option forces the background to be that of the `colorScheme` instead of that of the inline CSS.

For example, with the following type of HTML tag:

```html
<p style="background-color: white;">Hello World!</p>
```

the text would originally appear illegible and would not fit in with the dark mode (if enabled). If it was in light mode, everything would be OK.